### PR TITLE
Fix invalid pointer in CommandLine destructor

### DIFF
--- a/src/utils/command_parser.cpp
+++ b/src/utils/command_parser.cpp
@@ -8,7 +8,7 @@
 
 CommandLine::CommandLine() 
 {
-
+	command.options = NULL;
 }
 
 CommandLine::~CommandLine()


### PR DESCRIPTION
When CommandLine::parse is not called there is a risk that command.options can stay uninitialized. This would lead to its destructor failing after calling free() with an invalid pointer. To prevent it, this commit simply initializes command.options to NULL.
The error can be reproduced by calling ykushcmd with no arguments.